### PR TITLE
chore: update to Minecraft 1.21.8, Fabric API 0.131.0, ModMenu 15.0.0…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,8 +4,8 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21.7
-yarn_mappings=1.21.7+build.6
+minecraft_version=1.21.8
+yarn_mappings=1.21.8+build.1
 fabric_loader_version=0.16.14
 
 # Mod Properties
@@ -15,9 +15,9 @@ archives_base_name=elytraassistant
 modding_api=fabric
 
 # Dependencies
-fabric_api_version=0.129.0+1.21.7
+fabric_api_version=0.131.0+1.21.8
 # https://modrinth.com/mod/fabric-api/versions
-modmenu_version=7.2.2
-cloth_config_version=11.1.106
+modmenu_version=15.0.0-beta.3
+cloth_config_version=19.0.147
 
 # gradlew migrateMappings --mappings "1.21.1+build.3"

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -33,13 +33,13 @@
 		}
 	],
 	"depends": {
-		"fabricloader": ">=0.16.14",
-		"minecraft": ["1.21.7"],
-		"java": ">=21",
-		"fabric-api": "*",
-		"cloth-config": ">=15.0.128"
+	"fabricloader": ">=0.16.14",
+	"minecraft": ["1.21.8"],
+	"java": ">=21",
+	"fabric-api": "*",
+	"cloth-config": ">=19.0.147"
 	},
 	"suggests": {
-		"modmenu": ">=7.2.2"
+	"modmenu": ">=15.0.0-beta.3"
 	}
 }


### PR DESCRIPTION
## Upgrade ElytraAssistant to Minecraft 1.21.8 (Fabric)

### Summary
This PR updates ElytraAssistant to support Minecraft 1.21.8 using the latest Fabric toolchain and dependencies.

### Changes
- Bumped `minecraft_version` to **1.21.8**
- Updated Yarn mappings to **1.21.8+build.1**
- Upgraded Fabric API to **0.131.0+1.21.8**
- Updated ModMenu to **15.0.0-beta.3**
- Updated Cloth Config to **19.0.147**
- Updated `fabric.mod.json` dependency requirements

### Notes
- All dependencies are now compatible with 1.21.8.
- Please review for any breaking changes or additional migration steps.